### PR TITLE
Move @nrk/static-publish-cli to optionalDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First clone `@nrk/core-icons` and install its dependencies:
 ```bash
 git clone git@github.com:nrkno/core-icons.git
 cd core-icons
-npm install
+npm install --no-optional
 ```
 
 ## Building and committing

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "static-publish": "static-publish publish --directory ./dist --package ./package.json --verbose --latest"
   },
   "devDependencies": {
-    "@nrk/static-publish-cli": "^3.0.2",
     "cpx": "^1.5.0",
     "eslint": "^3.18.0",
     "eslint-config-nrk": "^5.1.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.1"
+  },
+  "optionalDependencies": {
+    "@nrk/static-publish-cli": "^3.0.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thinking to public-source this repo as well, but want to clarify optionalDependencies just like done in core-css first.