### PR TITLE
Generate individual icon files in js/jsx format on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ yarn-error*
 **/*.jsx.js
 **/jsx.js
 docs/
+index.js
+index.jsx
+nrk-*.js
+nrk-*.jsx

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,4 @@
-.DS_Store
-.npm
-.vscode
-.idea
+.*
 node_modules/
 npm-debug*
 yarn-error*
@@ -11,3 +8,7 @@ yarn-error*
 *.css
 *.md
 docs/
+src/
+dist/
+rollup.config.js
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,6 @@ yarn-error*
 *.md
 docs/
 src/
-dist/
+lib/
 rollup.config.js
 package-lock.json

--- a/lib/docs.md
+++ b/lib/docs.md
@@ -96,13 +96,13 @@ coreIcons()               // => returns Array of all icons: [{id, width, height,
 coreIcons('nrk-logo-nrk') // => returns Object {id, width, height, body, sprite, symbol, svg}
 
 // Where:
-// id     = {String} icon id
-// width  = {Number} original pixel width
-// height = {Number} original pixel height
-// body   = {String} HTML content of <svg>
-// sprite = {String} HTML <svg> tag with <use> for sprite usage
-// symbol = {String} HTML <symbol> tag. Usefull when generating a sprite
-// svg    = {String} HTML the actual <svg>
+coreIcons('nrk-logo-nrk').id     // => {String} icon id
+coreIcons('nrk-logo-nrk').width  // => {Number} original pixel width
+coreIcons('nrk-logo-nrk').height // => {Number} original pixel height
+coreIcons('nrk-logo-nrk').body   // => {String} HTML content of <svg>
+coreIcons('nrk-logo-nrk').sprite // => {String} HTML <svg> tag with <use> for sprite usage
+coreIcons('nrk-logo-nrk').symbol // => {String} HTML <symbol> tag. Usefull when generating a sprite
+coreIcons('nrk-logo-nrk').svg    // => {String} HTML the actual <svg>
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "author": "NRK <opensource@nrk.no> (https://www.nrk.no/)",
   "version": "4.1.0",
   "license": "MIT",
-  "main": "lib/core-icons.cjs.js",
+  "main": "index.js",
   "scripts": {
+    "clean": "rm -f nrk-*.{js,jsx}",
     "build": "rollup --config",
+    "prepublishOnly": "npm run build",
+    "postpublish": "npm run clean",
     "publish:patch": "npm version patch -m 'Release patch %s' && npm run push",
     "publish:minor": "npm version minor -m 'Release minor %s' && npm run push",
     "publish:major": "npm version major -m 'Release major %s' && npm run push",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "clean": "rm -f nrk-*.{js,jsx}",
+    "clean": "rm -f nrk-*.{mjs,js,jsx}",
     "build": "rollup --config",
     "prepublishOnly": "npm run build",
     "postpublish": "npm run clean",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "clean": "rm -f nrk-*.{mjs,js,jsx}",
+    "clean": "rm -f nrk-*.{mjs,jsx} && rm -f lib/nrk-*.js",
     "build": "rollup --config",
     "prepublishOnly": "npm run build",
     "postpublish": "npm run clean",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 import {uglify} from 'rollup-plugin-uglify'
 import buble from 'rollup-plugin-buble'
 import serve from 'rollup-plugin-serve'
-import path from 'path';
+import path from 'path'
 import pkg from './package.json'
 import fs from 'fs'
 
@@ -51,7 +51,7 @@ export default [{
   plugins: pluginsMIN
 }]
 
-function generateFiles() {
+function generateFiles () {
   const ext = '.svg'
   const files = fs.readdirSync('./lib').filter((file) => path.extname(file) === ext)
   const icons = files.reduce((icons, file) => {
@@ -67,7 +67,7 @@ function generateFiles() {
   const jsIndexTmpl = fs.readFileSync('./src/index-tmpl.js', 'utf8')
   const jsxIndexTmpl = fs.readFileSync('./src/index-tmpl.jsx', 'utf8')
   const sketch = fs.readFileSync('./lib/core-icons.rss', 'utf8')
-  const date = new Date(fs.statSync('./lib/core-icons.rss').mtime)
+  const date = new Date(fs.statSync('./lib/core-icons.sketch').mtime)
   const docs = fs.readFileSync('./lib/docs.md', 'utf8')
 
   for (const id in icons) {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -81,7 +81,7 @@ function generateFiles () {
       .replace('{{WIDTH}}', width)
       .replace('{{HEIGHT}}', height)
       .replace('{{ID}}', id)
-      fs.writeFileSync(`${id}.js`, jsIconContent)
+      fs.writeFileSync(`lib/${id}.js`, jsIconContent)
       const mjsIconContent = mjsIconTmpl
       .replace('{{BODY}}', body)
       .replace('{{WIDTH}}', width)

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -52,6 +52,8 @@ export default [{
 }]
 
 function generateFiles () {
+  const version = process.env['npm_package_version']
+  const major = version.slice(0, version.indexOf('.'))
   const ext = '.svg'
   const files = fs.readdirSync('./lib').filter((file) => path.extname(file) === ext)
   const icons = files.reduce((icons, file) => {
@@ -63,6 +65,7 @@ function generateFiles () {
   }, {})
 
   const jsIconTmpl = fs.readFileSync('./src/icon-tmpl.js', 'utf8')
+  const mjsIconTmpl = fs.readFileSync('./src/icon-tmpl.mjs', 'utf8')
   const jsxIconTmpl = fs.readFileSync('./src/icon-tmpl.jsx', 'utf8')
   const jsIndexTmpl = fs.readFileSync('./src/index-tmpl.js', 'utf8')
   const jsxIndexTmpl = fs.readFileSync('./src/index-tmpl.jsx', 'utf8')
@@ -73,11 +76,18 @@ function generateFiles () {
   for (const id in icons) {
     const [body, width, height] = icons[id]
     const jsIconContent = jsIconTmpl
+      .replace('{{GLOBAL}}', `coreIcons${major}`)
       .replace('{{BODY}}', body)
       .replace('{{WIDTH}}', width)
       .replace('{{HEIGHT}}', height)
       .replace('{{ID}}', id)
-    fs.writeFileSync(`${id}.js`, jsIconContent)
+      fs.writeFileSync(`${id}.js`, jsIconContent)
+      const mjsIconContent = mjsIconTmpl
+      .replace('{{BODY}}', body)
+      .replace('{{WIDTH}}', width)
+      .replace('{{HEIGHT}}', height)
+      .replace('{{ID}}', id)
+    fs.writeFileSync(`${id}.mjs`, mjsIconContent)
     const jsxIconContent = jsxIconTmpl
       .replace('{{BODY}}', body)
       .replace('{{WIDTH}}', width)

--- a/src/icon-tmpl.js
+++ b/src/icon-tmpl.js
@@ -5,4 +5,4 @@ var WIDTH = '{{WIDTH}}'
 /**
  * Render icon as independant SVG element
  */
-export default `<svg style="width:${WIDTH / 10}em;height:${HEIGHT / 10}em" viewBox="0 0 ${WIDTH} ${HEIGHT}" focusable="false" aria-hidden="true">${BODY}</svg>`
+{{GLOBAL}}['{{ID}}'] = `<svg style="width:${WIDTH / 10}em;height:${HEIGHT / 10}em" viewBox="0 0 ${WIDTH} ${HEIGHT}" focusable="false" aria-hidden="true">${BODY}</svg>`

--- a/src/icon-tmpl.js
+++ b/src/icon-tmpl.js
@@ -1,8 +1,1 @@
-var BODY = '{{BODY}}'
-var HEIGHT = '{{HEIGHT}}'
-var WIDTH = '{{WIDTH}}'
-
-/**
- * Render icon as independant SVG element
- */
-{{GLOBAL}}['{{ID}}'] = `<svg style="width:${WIDTH / 10}em;height:${HEIGHT / 10}em" viewBox="0 0 ${WIDTH} ${HEIGHT}" focusable="false" aria-hidden="true">${BODY}</svg>`
+{{GLOBAL}}['{{ID}}'] = ['{{BODY}}', {{WIDTH}}, {{HEIGHT}}]

--- a/src/icon-tmpl.js
+++ b/src/icon-tmpl.js
@@ -1,51 +1,18 @@
-export { renderAsSymbol, renderAsSprite, renderAsSVG };
-
-const BODY = '{{BODY}}';
-const HEIGHT = '{{HEIGHT}}';
-const ID = '{{ID}}';
-const WIDTH = '{{WIDTH}}';
-
-/**
- * Render icon as symbol definition
- */
-function renderAsSymbol() {
-  return '<symbol id=\"'
-    + ID
-    + '\" viewBox=\"0 0 '
-    + WIDTH
-    + ' '
-    + HEIGHT
-    + '\">'
-    + BODY
-    + '</symbol>';
-}
-
-/**
- * Render icon as sprite (referencing symbol definition)
- */
-function renderAsSprite() {
-  return '<svg style=\"width:'
-    + (WIDTH / 10)
-    + 'em;height:'
-    + (HEIGHT / 10)
-    + 'em\" focusable=\"false\" aria-hidden=\"true\"><use xlink:href=\"#'
-    + ID
-    + '\" /></svg>';
-}
+var BODY = '{{BODY}}';
+var HEIGHT = '{{HEIGHT}}';
+var WIDTH = '{{WIDTH}}';
 
 /**
  * Render icon as independant SVG element
  */
-function renderAsSVG() {
-  return '<svg style=\"width:'
-    + (WIDTH / 10)
-    + 'em;height:'
-    + (HEIGHT / 10)
-    + 'em\" viewBox=\"0 0 '
-    + WIDTH
-    + ' '
-    + HEIGHT
-    + '\" focusable=\"false\" aria-hidden=\"true\">'
-    + BODY
-    + '</svg>';
-}
+export default '<svg style=\"width:'
+  + (WIDTH / 10)
+  + 'em;height:'
+  + (HEIGHT / 10)
+  + 'em\" viewBox=\"0 0 '
+  + WIDTH
+  + ' '
+  + HEIGHT
+  + '\" focusable=\"false\" aria-hidden=\"true\">'
+  + BODY
+  + '</svg>';

--- a/src/icon-tmpl.js
+++ b/src/icon-tmpl.js
@@ -1,0 +1,51 @@
+export { renderAsSymbol, renderAsSprite, renderAsSVG };
+
+const BODY = '{{BODY}}';
+const HEIGHT = '{{HEIGHT}}';
+const ID = '{{ID}}';
+const WIDTH = '{{WIDTH}}';
+
+/**
+ * Render icon as symbol definition
+ */
+function renderAsSymbol() {
+  return '<symbol id=\"'
+    + ID
+    + '\" viewBox=\"0 0 '
+    + WIDTH
+    + ' '
+    + HEIGHT
+    + '\">'
+    + BODY
+    + '</symbol>';
+}
+
+/**
+ * Render icon as sprite (referencing symbol definition)
+ */
+function renderAsSprite() {
+  return '<svg style=\"width:'
+    + (WIDTH / 10)
+    + 'em;height:'
+    + (HEIGHT / 10)
+    + 'em\" focusable=\"false\" aria-hidden=\"true\"><use xlink:href=\"#'
+    + ID
+    + '\" /></svg>';
+}
+
+/**
+ * Render icon as independant SVG element
+ */
+function renderAsSVG() {
+  return '<svg style=\"width:'
+    + (WIDTH / 10)
+    + 'em;height:'
+    + (HEIGHT / 10)
+    + 'em\" viewBox=\"0 0 '
+    + WIDTH
+    + ' '
+    + HEIGHT
+    + '\" focusable=\"false\" aria-hidden=\"true\">'
+    + BODY
+    + '</svg>';
+}

--- a/src/icon-tmpl.js
+++ b/src/icon-tmpl.js
@@ -1,18 +1,8 @@
-var BODY = '{{BODY}}';
-var HEIGHT = '{{HEIGHT}}';
-var WIDTH = '{{WIDTH}}';
+var BODY = '{{BODY}}'
+var HEIGHT = '{{HEIGHT}}'
+var WIDTH = '{{WIDTH}}'
 
 /**
  * Render icon as independant SVG element
  */
-export default '<svg style=\"width:'
-  + (WIDTH / 10)
-  + 'em;height:'
-  + (HEIGHT / 10)
-  + 'em\" viewBox=\"0 0 '
-  + WIDTH
-  + ' '
-  + HEIGHT
-  + '\" focusable=\"false\" aria-hidden=\"true\">'
-  + BODY
-  + '</svg>';
+export default `<svg style="width:${WIDTH / 10}em;height:${HEIGHT / 10}em" viewBox="0 0 ${WIDTH} ${HEIGHT}" focusable="false" aria-hidden="true">${BODY}</svg>`

--- a/src/icon-tmpl.jsx
+++ b/src/icon-tmpl.jsx
@@ -1,41 +1,13 @@
 import React from 'react'
 
-export { renderAsSymbol, renderAsSprite, renderAsSVG };
-
-const BODY = '{{BODY}}';
-const HEIGHT = '{{HEIGHT}}';
-const ID = '{{ID}}';
-const WIDTH = '{{WIDTH}}';
-
-/**
- * Render icon as symbol definition
- */
-function renderAsSymbol() {
-  return React.createElement('symbol', {
-    dangerouslySetInnerHTML: { __html: BODY },
-    id: ID,
-    viewbox: '0 0 ' + WIDTH + ' ' + HEIGHT
-  });
-}
-
-/**
- * Render icon as sprite (referencing symbol definition)
- */
-function renderAsSprite() {
-  return React.createElement('svg', {
-    'aria-hidden': true,
-    focusable: false,
-    style: {
-      height: '' + (HEIGHT / 10) + 'em',
-      width: '' + (WIDTH / 10) + 'em'
-    }
-  }, [React.createElement('use', { 'xlink:href': '#' + ID })]);
-}
+var BODY = '{{BODY}}';
+var HEIGHT = '{{HEIGHT}}';
+var WIDTH = '{{WIDTH}}';
 
 /**
  * Render icon as independant SVG element
  */
-function renderAsSVG() {
+export default function renderSVG() {
   return React.createElement('svg', {
     'aria-hidden': true,
     dangerouslySetInnerHTML: { __html: BODY },

--- a/src/icon-tmpl.jsx
+++ b/src/icon-tmpl.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+
+export { renderAsSymbol, renderAsSprite, renderAsSVG };
+
+const BODY = '{{BODY}}';
+const HEIGHT = '{{HEIGHT}}';
+const ID = '{{ID}}';
+const WIDTH = '{{WIDTH}}';
+
+/**
+ * Render icon as symbol definition
+ */
+function renderAsSymbol() {
+  return React.createElement('symbol', {
+    dangerouslySetInnerHTML: { __html: BODY },
+    id: ID,
+    viewbox: '0 0 ' + WIDTH + ' ' + HEIGHT
+  });
+}
+
+/**
+ * Render icon as sprite (referencing symbol definition)
+ */
+function renderAsSprite() {
+  return React.createElement('svg', {
+    'aria-hidden': true,
+    focusable: false,
+    style: {
+      height: '' + (HEIGHT / 10) + 'em',
+      width: '' + (WIDTH / 10) + 'em'
+    }
+  }, [React.createElement('use', { 'xlink:href': '#' + ID })]);
+}
+
+/**
+ * Render icon as independant SVG element
+ */
+function renderAsSVG() {
+  return React.createElement('svg', {
+    'aria-hidden': true,
+    dangerouslySetInnerHTML: { __html: BODY },
+    focusable: false,
+    style: {
+      height: '' + (HEIGHT / 10) + 'em',
+      width: '' + (WIDTH / 10) + 'em'
+    },
+    viewbox: '0 0 ' + WIDTH + ' ' + HEIGHT
+  });
+}

--- a/src/icon-tmpl.jsx
+++ b/src/icon-tmpl.jsx
@@ -1,21 +1,21 @@
 import React from 'react'
 
-var BODY = '{{BODY}}';
-var HEIGHT = '{{HEIGHT}}';
-var WIDTH = '{{WIDTH}}';
+const BODY = '{{BODY}}'
+const HEIGHT = '{{HEIGHT}}'
+const WIDTH = '{{WIDTH}}'
 
 /**
  * Render icon as independant SVG element
  */
-export default function renderSVG() {
+export default function renderSVG () {
   return React.createElement('svg', {
     'aria-hidden': true,
     dangerouslySetInnerHTML: { __html: BODY },
     focusable: false,
     style: {
-      height: '' + (HEIGHT / 10) + 'em',
-      width: '' + (WIDTH / 10) + 'em'
+      height: `${HEIGHT / 10}em`,
+      width: `${WIDTH / 10}em`
     },
-    viewbox: '0 0 ' + WIDTH + ' ' + HEIGHT
-  });
+    viewbox: `0 0 ${WIDTH} ${HEIGHT}`
+  })
 }

--- a/src/icon-tmpl.mjs
+++ b/src/icon-tmpl.mjs
@@ -1,0 +1,8 @@
+var BODY = '{{BODY}}'
+var HEIGHT = '{{HEIGHT}}'
+var WIDTH = '{{WIDTH}}'
+
+/**
+ * Render icon as independant SVG element
+ */
+export default `<svg style="width:${WIDTH / 10}em;height:${HEIGHT / 10}em" viewBox="0 0 ${WIDTH} ${HEIGHT}" focusable="false" aria-hidden="true">${BODY}</svg>`

--- a/src/index-tmpl.js
+++ b/src/index-tmpl.js
@@ -1,0 +1,68 @@
+const ICONS = {{ICONS}};
+
+module.exports = {
+  renderSymbols,
+  renderSymbol,
+  renderSprite,
+  renderSVG
+};
+
+/**
+ * Render one or more icons as block of symbol definitions
+ * @param {[string]} [ids]
+ * @returns {string}
+ */
+function renderSymbols(ids = Object.keys(ICONS)) {
+  if (!Array.isArray(ids)) {
+    ids = [ids];
+  }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+    ${ids.forEach(renderSymbol)}
+  </svg>`;
+}
+
+/**
+ * Render icon with 'id' as symbol definition
+ * @param {string} id
+ * @returns {string}
+ */
+function renderSymbol(id) {
+  if (!ICONS.hasOwnProperty(id)) {
+    return '';
+  }
+
+  const [body, width, height] = ICONS[id];
+
+  return `<symbol id="${id}" viewBox="0 0 ${width} ${height}">${body}</symbol>`;
+}
+
+/**
+ * Render icon with 'id' as sprite (referencing symbol definition)
+ * @param {string} id
+ * @returns {string}
+ */
+function renderSprite(id) {
+  if (!ICONS.hasOwnProperty(id)) {
+    return '';
+  }
+
+  const [body, width, height] = ICONS[id];
+
+  return `<svg style="width:${width / 10}em;height:${height / 10}em" focusable="false" aria-hidden="true"><use xlink:href="#${id}" /></svg>`;
+}
+
+/**
+ * Render icon with 'id' as independant SVG element
+ * @param {string} id
+ * @returns {string}
+ */
+function renderSVG(id) {
+  if (!ICONS.hasOwnProperty(id)) {
+    return '';
+  }
+
+  const [body, width, height] = ICONS[id];
+
+  return `<svg style="width:${width / 10}em;height:${height / 10}em" viewBox="0 0 ${width} ${height}" focusable="false" aria-hidden="true">${body}</svg>`;
+}

--- a/src/index-tmpl.js
+++ b/src/index-tmpl.js
@@ -1,25 +1,23 @@
-const ICONS = {{ICONS}};
+const ICONS = '{{ICONS}}'
 
 module.exports = {
   renderSymbols,
   renderSymbol,
   renderSprite,
   renderSVG
-};
+}
 
 /**
  * Render one or more icons as block of symbol definitions
  * @param {[string]} [ids]
  * @returns {string}
  */
-function renderSymbols(ids = Object.keys(ICONS)) {
-  if (!Array.isArray(ids)) {
-    ids = [ids];
-  }
+function renderSymbols (ids = Object.keys(ICONS)) {
+  if (!Array.isArray(ids)) ids = [ids]
 
   return `<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
     ${ids.forEach(renderSymbol)}
-  </svg>`;
+  </svg>`
 }
 
 /**
@@ -27,14 +25,12 @@ function renderSymbols(ids = Object.keys(ICONS)) {
  * @param {string} id
  * @returns {string}
  */
-function renderSymbol(id) {
-  if (!ICONS.hasOwnProperty(id)) {
-    return '';
-  }
+function renderSymbol (id) {
+  if (!ICONS.hasOwnProperty(id)) return ''
 
-  const [body, width, height] = ICONS[id];
+  const [body, width, height] = ICONS[id]
 
-  return `<symbol id="${id}" viewBox="0 0 ${width} ${height}">${body}</symbol>`;
+  return `<symbol id="${id}" viewBox="0 0 ${width} ${height}">${body}</symbol>`
 }
 
 /**
@@ -42,14 +38,12 @@ function renderSymbol(id) {
  * @param {string} id
  * @returns {string}
  */
-function renderSprite(id) {
-  if (!ICONS.hasOwnProperty(id)) {
-    return '';
-  }
+function renderSprite (id) {
+  if (!ICONS.hasOwnProperty(id)) return ''
 
-  const [body, width, height] = ICONS[id];
+  const [, width, height] = ICONS[id]
 
-  return `<svg style="width:${width / 10}em;height:${height / 10}em" focusable="false" aria-hidden="true"><use xlink:href="#${id}" /></svg>`;
+  return `<svg style="width:${width / 10}em;height:${height / 10}em" focusable="false" aria-hidden="true"><use xlink:href="#${id}" /></svg>`
 }
 
 /**
@@ -57,12 +51,10 @@ function renderSprite(id) {
  * @param {string} id
  * @returns {string}
  */
-function renderSVG(id) {
-  if (!ICONS.hasOwnProperty(id)) {
-    return '';
-  }
+function renderSVG (id) {
+  if (!ICONS.hasOwnProperty(id)) return ''
 
-  const [body, width, height] = ICONS[id];
+  const [body, width, height] = ICONS[id]
 
-  return `<svg style="width:${width / 10}em;height:${height / 10}em" viewBox="0 0 ${width} ${height}" focusable="false" aria-hidden="true">${body}</svg>`;
+  return `<svg style="width:${width / 10}em;height:${height / 10}em" viewBox="0 0 ${width} ${height}" focusable="false" aria-hidden="true">${body}</svg>`
 }

--- a/src/index-tmpl.jsx
+++ b/src/index-tmpl.jsx
@@ -1,30 +1,28 @@
-const React = require('react');
+const React = require('react')
 
-const ICONS = {{ICONS}};
+const ICONS = '{{ICONS}}'
 
 module.exports = {
   renderSymbols,
   renderSymbol,
   renderSprite,
   renderSVG
-};
+}
 
 /**
  * Render one or more icons as block of symbol definitions
  * @param {[string]} [ids]
  * @returns {string}
  */
-function renderSymbols(ids = Object.keys(ICONS)) {
-  if (!Array.isArray(ids)) {
-    ids = [ids];
-  }
+function renderSymbols (ids = Object.keys(ICONS)) {
+  if (!Array.isArray(ids)) ids = [ids]
 
   return React.createElement('svg', {
     xmlns: 'http://www.w3.org/2000/svg',
     style: {
       display: 'none'
     }
-  }, ids.forEach(renderSymbol));
+  }, ids.forEach(renderSymbol))
 }
 
 /**
@@ -32,18 +30,16 @@ function renderSymbols(ids = Object.keys(ICONS)) {
  * @param {string} id
  * @returns {string}
  */
-function renderSymbol(id) {
-  if (!ICONS.hasOwnProperty(id)) {
-    return null;
-  }
+function renderSymbol (id) {
+  if (!ICONS.hasOwnProperty(id)) return null
 
-  const [body, width, height] = ICONS[id];
+  const [body, width, height] = ICONS[id]
 
   return React.createElement('symbol', {
     dangerouslySetInnerHTML: { __html: body },
     id,
     viewbox: `0 0 ${width} ${height}`
-  });
+  })
 }
 
 /**
@@ -51,12 +47,10 @@ function renderSymbol(id) {
  * @param {string} id
  * @returns {string}
  */
-function renderSprite(id) {
-  if (!ICONS.hasOwnProperty(id)) {
-    return null;
-  }
+function renderSprite (id) {
+  if (!ICONS.hasOwnProperty(id)) return null
 
-  const [body, width, height] = ICONS[id];
+  const [, width, height] = ICONS[id]
 
   return React.createElement('svg', {
     'aria-hidden': true,
@@ -65,9 +59,7 @@ function renderSprite(id) {
       width: `${width / 10}em`,
       height: `${height / 10}em`
     }
-  }, [React.createElement('use', {
-    'xlink:href': `#${id}`
-  })]);
+  }, [React.createElement('use', {'xlink:href': `#${id}`})])
 }
 
 /**
@@ -75,12 +67,10 @@ function renderSprite(id) {
  * @param {string} id
  * @returns {string}
  */
-function renderSVG(id) {
-  if (!ICONS.hasOwnProperty(id)) {
-    return null;
-  }
+function renderSVG (id) {
+  if (!ICONS.hasOwnProperty(id)) return null
 
-  const [body, width, height] = ICONS[id];
+  const [body, width, height] = ICONS[id]
 
   return React.createElement('svg', {
     'aria-hidden': true,
@@ -91,5 +81,5 @@ function renderSVG(id) {
       height: `${height / 10}em`
     },
     viewbox: `0 0 ${width} ${height}`
-  });
+  })
 }

--- a/src/index-tmpl.jsx
+++ b/src/index-tmpl.jsx
@@ -1,0 +1,95 @@
+const React = require('react');
+
+const ICONS = {{ICONS}};
+
+module.exports = {
+  renderSymbols,
+  renderSymbol,
+  renderSprite,
+  renderSVG
+};
+
+/**
+ * Render one or more icons as block of symbol definitions
+ * @param {[string]} [ids]
+ * @returns {string}
+ */
+function renderSymbols(ids = Object.keys(ICONS)) {
+  if (!Array.isArray(ids)) {
+    ids = [ids];
+  }
+
+  return React.createElement('svg', {
+    xmlns: 'http://www.w3.org/2000/svg',
+    style: {
+      display: 'none'
+    }
+  }, ids.forEach(renderSymbol));
+}
+
+/**
+ * Render icon with 'id' as symbol definition
+ * @param {string} id
+ * @returns {string}
+ */
+function renderSymbol(id) {
+  if (!ICONS.hasOwnProperty(id)) {
+    return null;
+  }
+
+  const [body, width, height] = ICONS[id];
+
+  return React.createElement('symbol', {
+    dangerouslySetInnerHTML: { __html: body },
+    id,
+    viewbox: `0 0 ${width} ${height}`
+  });
+}
+
+/**
+ * Render icon with 'id' as sprite (referencing symbol definition)
+ * @param {string} id
+ * @returns {string}
+ */
+function renderSprite(id) {
+  if (!ICONS.hasOwnProperty(id)) {
+    return null;
+  }
+
+  const [body, width, height] = ICONS[id];
+
+  return React.createElement('svg', {
+    'aria-hidden': true,
+    focusable: false,
+    style: {
+      width: `${width / 10}em`,
+      height: `${height / 10}em`
+    }
+  }, [React.createElement('use', {
+    'xlink:href': `#${id}`
+  })]);
+}
+
+/**
+ * Render icon with 'id' as independant SVG element
+ * @param {string} id
+ * @returns {string}
+ */
+function renderSVG(id) {
+  if (!ICONS.hasOwnProperty(id)) {
+    return null;
+  }
+
+  const [body, width, height] = ICONS[id];
+
+  return React.createElement('svg', {
+    'aria-hidden': true,
+    dangerouslySetInnerHTML: { __html: body },
+    focusable: false,
+    style: {
+      width: `${width / 10}em`,
+      height: `${height / 10}em`
+    },
+    viewbox: `0 0 ${width} ${height}`
+  });
+}


### PR DESCRIPTION
Generate all icon files as `/nrk-*.{js,jsx}` for use in the browser/server, as well as `/index.{js,jsx}` for use on the server.

I'd also suggest moving all `*.svg` files to `/src/svg` from `/lib`, and renaming `/lib` to `/dist` to more clearly indicate intention (that `/dist` is published to static server).