### PR TITLE
Correctly label by state for picture-in-picture icons

### DIFF
--- a/lib/nrk-media-picture-in-picture--active.svg
+++ b/lib/nrk-media-picture-in-picture--active.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M10 11v10h13V11H10zm11 8h-9v-6h9v6z"/><path fill="currentColor" opacity=".5" d="M3 17V5h18v4h2V3H1v16h7v-2H3z"/></svg>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" opacity=".5" fill-rule="evenodd" clip-rule="evenodd" d="M10 11v10h13V11H10zm11 8h-9v-6h9v6z"/><path fill="currentColor" d="M3 17V5h18v4h2V3H1v16h7v-2H3z"/></svg>

--- a/lib/nrk-media-picture-in-picture.svg
+++ b/lib/nrk-media-picture-in-picture.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" opacity=".5" fill-rule="evenodd" clip-rule="evenodd" d="M10 11v10h13V11H10zm11 8h-9v-6h9v6z"/><path fill="currentColor" d="M3 17V5h18v4h2V3H1v16h7v-2H3z"/></svg>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M10 11v10h13V11H10zm11 8h-9v-6h9v6z"/><path fill="currentColor" opacity=".5" d="M3 17V5h18v4h2V3H1v16h7v-2H3z"/></svg>


### PR DESCRIPTION
Posted by @simenmyklebust
> Forslag om å endre ikon-state for Picture-in-Picture (PiP):
Bytte om på active/inactive state av Picture-in-Picture ikon (nrk-media-picture-in-picture) i [Core Icons](https://static.nrk.no/core-icons/latest/index.html) sånn at ikonet viser state du går til i stedet for state du er i.
PiP-ikonet oppfører seg i dag motsatt av fullskjerm-ikon som er et tilsvarende ikon (er også motsatt av hva andre aktører som f.eks. Apple og Youtube gjør).
For å få dette til å oppdatere seg overalt hvor PiP brukes, er det så enkelt som å bare bytte om i Core Icons, eller er det utfordringer som kan dukke opp som følge av det?

Old:
![Screenshot 2022-04-04 at 14 52 10](https://user-images.githubusercontent.com/2345608/161547781-fa279cb5-8d61-47df-aebb-d10c18c330aa.png)

New:
![Screenshot 2022-04-04 at 14 41 58](https://user-images.githubusercontent.com/2345608/161547818-fbf7dff7-ab20-41ab-b8dd-922f2aef8a38.png)

This constitutes a breaking change, and will be released as a new major version. Any other icons in need of a similar update as well?