### PR TITLE
Base equivalent icons

### DIFF
--- a/lib/icon/nrk-arrow-down.svg
+++ b/lib/icon/nrk-arrow-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="m12 20-7-4.9v-2.27l6 4.2V4l2 1v12.03l6-4.2v2.27L12 20Z" clip-rule="evenodd"/></svg>

--- a/lib/icon/nrk-arrow-up.svg
+++ b/lib/icon/nrk-arrow-up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="m12 4 7 4.9v2.27l-6-4.2V20l-2-1V6.97l-6 4.2V8.9L12 4Z" clip-rule="evenodd"/></svg>

--- a/lib/icon/nrk-checkbox--active.svg
+++ b/lib/icon/nrk-checkbox--active.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M3 21V3h18v18H3Zm6.95-4.03 8.26-8.26-1.41-1.42-6.74 6.74L7.5 11.1 6 12.4l3.95 4.57Z" clip-rule="evenodd"/></svg>

--- a/lib/icon/nrk-checkbox.svg
+++ b/lib/icon/nrk-checkbox.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M20 4H4v16h16V4Zm-2 2H6v12h12V6Z" clip-rule="evenodd" opacity=".5"/></svg>

--- a/lib/icon/nrk-media-tilgjengelighet-snartutilgjengelig.svg
+++ b/lib/icon/nrk-media-tilgjengelighet-snartutilgjengelig.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M13.32 12 19 18.63V23H5v-4.38l4.37-4.86 1.32 1.52L7.35 19h9.33L5 5.37V1h14v4.37L13.32 12Zm1.65-5L17 4.63V3H7v1.63L9.03 7h5.94Z" clip-rule="evenodd"/></svg>


### PR DESCRIPTION
Add the following base icons to match expressive equivalents
* `nrk-arrow-down`
* `nrk-arrow-up`
* `nrk-checkbox--active`
* `nrk-checkbox`
* `nrk-media-tilgjengelighet-snartutilgjengelig`