### PR TITLE
chore: add a check-action to build and verify npm bundle

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,17 @@
+name: Build and dry-run publish to npmjs
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm
+      - run: npm ci
+      # Build to verify
+      - run: npm run build
+      # Dry-run a publish to log package contents
+      - run: npm publish --dry-run


### PR DESCRIPTION
First step in moving to use github actions to build and release to npmjs and cdn