### PR TITLE
feat: add nrk-edit icon

### DIFF
--- a/lib/icon/nrk-edit.svg
+++ b/lib/icon/nrk-edit.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path d="M15.9 2 3 14.9v5.7h5.7L21.5 7.7 15.9 2ZM7.8 18.5H5v-2.8l7.9-7.9 2.8 2.8-7.9 7.9Zm6.5-12.1 1.6-1.6 2.8 2.8-1.6 1.6-2.8-2.8Z"/><path d="M12 21h8.6v-2H14l-2 2Z" opacity=".5"/></svg>


### PR DESCRIPTION
Added `nrk-edit` icon
 * optimized through svgomg
 * removed explicit `height` and `width`
 * replaced fill with `currentColor`

resolves #217 

Reviewers: 
 * Ref #218 should this icon have a duotone identifier in the name? e.g. `nrk-edit-dutone`?
   * And if so do we have a non-duotone icon we should add as well?