### PR TITLE
Declare the icons "as const" instead of strings

### DIFF
--- a/android/icons/src/main/kotlin/no/nrk/core/icons/NrkIcons.kt
+++ b/android/icons/src/main/kotlin/no/nrk/core/icons/NrkIcons.kt
@@ -378,6 +378,11 @@ object NrkIcons {
 		expressive = R.drawable.nrk_hardware_microphone_expressive
 	)
 
+	val NrkHardwareMicrophoneActive = NrkIcon(
+		normal = R.drawable.nrk_hardware_microphone__active,
+		expressive = R.drawable.nrk_hardware_microphone_expressive__active
+	)
+
 	val NrkHardwareMobile = NrkIcon(
 		normal = R.drawable.nrk_hardware_mobile,
 		expressive = null

--- a/android/icons/src/main/res/drawable/nrk_hardware_microphone__active.xml
+++ b/android/icons/src/main/res/drawable/nrk_hardware_microphone__active.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFF0F0F0"
+        android:fillType="evenOdd"
+        android:pathData="M8 14V2h8v12H8Z"/>
+    <path
+        android:fillColor="#FFF0F0F0"
+        android:pathData="M6 12H4v6h7v2H8v2h8v-2h-3v-2h7v-6h-2v4H6v-4Z"/>
+</vector>

--- a/android/icons/src/main/res/drawable/nrk_hardware_microphone_expressive__active.xml
+++ b/android/icons/src/main/res/drawable/nrk_hardware_microphone_expressive__active.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFF0F0F0"
+        android:fillType="evenOdd"
+        android:pathData="M12 14a4 4 0 0 1-4-4V6a4 4 0 1 1 8 0v4a4 4 0 0 1-4 4Z"/>
+    <path
+        android:fillColor="#FFF0F0F0"
+        android:pathData="M6 13a1 1 0 1 0-2 0v2a3 3 0 0 0 3 3h4v2H9a1 1 0 1 0 0 2h6a1 1 0 1 0 0-2h-2v-2h4a3 3 0 0 0 3-3v-2a1 1 0 1 0-2 0v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2Z"/>
+</vector>

--- a/bin/build.js
+++ b/bin/build.js
@@ -123,10 +123,16 @@ function buildIcons (groupName) {
   createZipArchive(staticDest, '**/*.pdf', staticFolder, `${bundleName}-pdf`)
 
   // svgToJs
+  const customOutputs = [
+    {
+      parser: ({ camelCase, svg }) => `export declare const ${camelCase}: '${svg}'`,
+    },
+  ]
   const icons = svgToJS({
     input: staticDest,
     banner: `@nrk/core-icons ${groupName} v${version}`,
-    scale: 16
+    scale: 16,
+    customOutputs
   })
   // Generate iife
   fse.writeFileSync(
@@ -139,7 +145,7 @@ function buildIcons (groupName) {
   // Generate js and mjs with types for icons and logos
   fse.writeFileSync(path.join(npmPath, `${bundleName}.js`), icons.cjs)
   fse.writeFileSync(path.join(npmPath, `${bundleName}.mjs`), icons.esm)
-  fse.writeFileSync(path.join(npmPath, `${bundleName}.d.ts`), icons.dts)
+  fse.writeFileSync(path.join(npmPath, `${bundleName}.d.ts`), icons.custom_1)
 
   // Generate jsx and mjsx with types for icons and logos
   fse.writeFileSync(path.join(npmJsxFolder, npmPath, `${bundleName}.js`), icons.cjsx)
@@ -154,7 +160,8 @@ function buildIcons (groupName) {
         const largeIcons = svgToJS({
           input: staticLargeDest,
           banner: `@nrk/core-icons ${groupName} v${version}`,
-          scale: 16
+          scale: 16,
+          customOutputs
         })
         const npmLargePath = path.join(npmPath, 'large')
         const largeBundleName = `${bundleName}-large`
@@ -170,7 +177,7 @@ function buildIcons (groupName) {
         // Generate js and mjs with types for icons and logos
         fse.writeFileSync(path.join(npmLargePath, `${largeBundleName}.js`), largeIcons.cjs)
         fse.writeFileSync(path.join(npmLargePath, `${largeBundleName}.mjs`), largeIcons.esm)
-        fse.writeFileSync(path.join(npmLargePath, `${largeBundleName}.d.ts`), largeIcons.dts)
+        fse.writeFileSync(path.join(npmLargePath, `${largeBundleName}.d.ts`), largeIcons.custom_1)
 
         // Generate jsx and mjsx with types for icons and logos
         fse.writeFileSync(path.join(npmJsxFolder, npmLargePath, `${largeBundleName}.js`), largeIcons.cjsx)


### PR DESCRIPTION
Makes it possible to separate and group the icons by type:

```
export type CoreIcon = `<svg ${string}class="nrk-${string}</svg>`;
export type CoreIconExpressive = `<svg ${string}class="nrk-${string}-expressive${string}</svg>`;
export type CoreIconLogo = `<svg ${string}class="nrk-logo-${string}</svg>`;
export type CoreIconBaseline<T extends CoreIcon> = T extends CoreIconExpressive ? never : T extends CoreIconLogo ? never : T;
```

It's not...perfect, but it allows for some basic type safety. Then we can drop `import *` which breaks tree shaking in nrk-tv-web.