### PR TITLE
fix: Remove explicit color fill-rules for nrk-radio(-expressive)--active

### DIFF
--- a/lib/expressive/nrk-radio-expressive--active.svg
+++ b/lib/expressive/nrk-radio-expressive--active.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="currentColor" d="M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"/><path fill="#000" fill-rule="evenodd" d="M12 19a7 7 0 1 0 0-14 7 7 0 0 0 0 14Zm0 2a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z" clip-rule="evenodd"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path d="M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z" /><path fill-rule="evenodd" d="M12 19a7 7 0 1 0 0-14 7 7 0 0 0 0 14Zm0 2a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z" clip-rule="evenodd" /></svg>

--- a/lib/icon/nrk-radio--active.svg
+++ b/lib/icon/nrk-radio--active.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="currentColor" d="M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"/><path fill="#000" fill-rule="evenodd" d="M12 19a7 7 0 1 0 0-14 7 7 0 0 0 0 14Zm0 2a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z" clip-rule="evenodd"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path d="M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z" /><path fill-rule="evenodd" d="M12 19a7 7 0 1 0 0-14 7 7 0 0 0 0 14Zm0 2a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z" clip-rule="evenodd" /></svg>


### PR DESCRIPTION
Cleaned up fill-rules causing only parts of the icon to change color.
e.g. with `color:white;` the icon would draw like this:
![Screenshot 2024-08-13 at 10 26 44](https://github.com/user-attachments/assets/c1e5c81c-ff40-47ab-9002-b9292bf6503d)
