### PR TITLE
Parse out logos for Android

### DIFF
--- a/.github/scripts/generate-android-vectors.js
+++ b/.github/scripts/generate-android-vectors.js
@@ -6,9 +6,9 @@ const svg2vectordrawable = require('svg2vectordrawable/src/svg-file-to-vectordra
 const CORE_ICON_DIRECTORIES = [
     "lib/expressive",
     "lib/icon",
+    "lib/logo"
     // TODO are these needed? Especially preview?
     //  There's also a directory called lib/logo/large which has to be handled somehow now
-    //"lib/logo",
     //"lib/preview"
 ]
 const ANDROID_DRAWABLE_FOLDER = "android/icons/src/main/res/drawable"
@@ -39,9 +39,18 @@ async function convertSvgToXml() {
         const files = fs.readdirSync(directory)
 
         for (const file of files) {
+            const fullPath = path.join(directory, file)
+            const stats = fs.statSync(fullPath)
+
+            // TODO maybe we should handle subdirectories somehow, not really needed now so I'm not adding it either
+            if (stats.isDirectory()) {
+                console.log(`Skipping "${file}" because it is a directory`)
+                continue
+            }
+
             const xmlFileName = file.replace(".svg", ".xml").replaceAll("-", "_").toLowerCase()
             if (!/^([a-z0-9\_])+\.xml$/.test(xmlFileName)) {
-                console.error(`Invalid file name: "${file}"! (output xml name: "${xmlFileName})`)
+                console.error(`Invalid file name: "${file}"! (output xml name: "${xmlFileName})"`)
                 hasErrors = true
 
                 continue


### PR DESCRIPTION
Logoer blir nå eksponert på samme måte som andre ikoner, for eks `NrkIcons.NrkLogoNrk1`. Jeg har ignorert [/lib/logo/large](https://github.com/nrkno/core-icons/tree/master/lib/logo/large) siden det krever litt mer endringer for å få subdirectories til å fungere, og det er ikke noen av logoene her vi trenger nå

Kunne vurdert å splitte opp det her i `NrkIcons` og `NrkLogos`, men går sikkert fint å bare samle alt i ett

Kan testes lokalt ved å kjøre `node .\.github\scripts\generate-android-vectors.js` og gå i MainActivity og se at man får tak i logoer med `NrkIcons.NrkLogoNrk1`