### PR TITLE
feat: nrk-hardware-radio--active, nrk-hardware-radio-expressive--active

### DIFF
--- a/lib/expressive/nrk-hardware-radio-expressive--active.svg
+++ b/lib/expressive/nrk-hardware-radio-expressive--active.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="m6.047 4 1.25-2.454a1 1 0 1 1 1.782.908L8.29 4H20a3 3 0 0 1 3 3v10a3 3 0 0 1-3 3H4a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3zM8.5 12a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0m4.5 0a2 2 0 1 0 4 0 2 2 0 0 0-4 0m-2 0a4 4 0 1 0 8 0 4 4 0 0 0-8 0" clip-rule="evenodd"/></svg>

--- a/lib/icon/nrk-hardware-radio--active.svg
+++ b/lib/icon/nrk-hardware-radio--active.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" d="m6 4 1.6-3h2.2L8.3 4H23v16H1V4zm2.5 8a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0m4.5 0a2 2 0 1 0 4 0 2 2 0 0 0-4 0m-2 0a4 4 0 1 0 8 0 4 4 0 0 0-8 0" clip-rule="evenodd"/></svg>


### PR DESCRIPTION
Source: [Core Icons Figma](https://www.figma.com/design/KXGJ6Qcdf8JAyRCoKV55If/NRK-Core-Icons?node-id=6353-2&t=igWxu9DTyf5RYr8a-4)

- [x] It has fill-rule of `fill="currentColor"`
- [x] It has no fill-rules with explicit color values like `fill="#f0f0f0"`
- [x] It has been trimmed using a minifier like [SVGOMG](https://jakearchibald.github.io/svgomg/). (Lowest precision without visual degradation)
- [x] It has viewbox of `viewBox="0 0 24 24"` (except logos)
- [x] It has no explicit width/height
