### PR TITLE
Add new portrait-to-landscape and landscape-to-portrait icons

### DIFF
--- a/lib/expressive/nrk-rectangle-landscape-to-portrait-expressive.svg
+++ b/lib/expressive/nrk-rectangle-landscape-to-portrait-expressive.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M12 9h-2V4H4v10h1.09v2H2V2h10z" opacity=".5"/>
+  <path fill="currentColor" d="M22 12v10H8V12zm-12 8h10v-6H10zM22 8.367l-3 1.63-3-1.63v-2.37l2 1.086V4h-3V2h5v5.083l2-1.086z"/>
+</svg>

--- a/lib/expressive/nrk-rectangle-portrait-to-landscape-expressive.svg
+++ b/lib/expressive/nrk-rectangle-portrait-to-landscape-expressive.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M9 12v2H3.867v6h10.266v-1H16v3H2V12z" opacity=".5"/>
+  <path fill="currentColor" d="M22 16H12V2h10zM14 4v10h6V4zM8.4 2 10 5 8.4 8H6l1.1-2H4v3H2V4h5.1L6 2z"/>
+</svg>

--- a/lib/icon/nrk-rectangle-landscape-to-portrait.svg
+++ b/lib/icon/nrk-rectangle-landscape-to-portrait.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M6.65 2.2a1 1 0 0 1 1.4.2L10 5 8.05 7.6a1 1 0 0 1-1.6-1.2l.3-.4H5a1 1 0 0 0-1 1v1.5a1 1 0 0 1-2 0V7a3 3 0 0 1 3-3h1.75l-.3-.4a1 1 0 0 1 .2-1.4"/>
+  <path fill="currentColor" fill-rule="evenodd" d="M12 5a3 3 0 0 1 3-3h4a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3h-4a3 3 0 0 1-3-3zm2 8a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1z" clip-rule="evenodd"/>
+  <path fill="currentColor" d="M13 22a3 3 0 0 0 3-3h-2a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1h3.9v-2H5a3 3 0 0 0-3 3v4a3 3 0 0 0 3 3z" opacity=".5"/>
+</svg>

--- a/lib/icon/nrk-rectangle-portrait-to-landscape.svg
+++ b/lib/icon/nrk-rectangle-portrait-to-landscape.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path fill="currentColor" d="M17 2a3 3 0 0 1 3 3v1.766l.4-.3a1 1 0 1 1 1.2 1.6L19 10l-2.6-1.935a1 1 0 1 1 1.2-1.6l.4.3V5a1 1 0 0 0-1-1h-2.5a1 1 0 1 1 0-2z"/>
+  <path fill="currentColor" fill-rule="evenodd" d="M19 12a3 3 0 0 1 3 3v4a3 3 0 0 1-3 3h-8a3 3 0 0 1-3-3v-4a3 3 0 0 1 3-3zm-8 2a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-4a1 1 0 0 0-1-1z" clip-rule="evenodd"/>
+  <path fill="currentColor" d="M2 13a3 3 0 0 0 3 3v-2a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v3.9h2V5a3 3 0 0 0-3-3H5a3 3 0 0 0-3 3z" opacity=".5"/>
+</svg>

--- a/lib/readme.md
+++ b/lib/readme.md
@@ -132,16 +132,16 @@ npm install @nrk/core-icons
 
 We host the following scripts for use in the browser on our cdn
 
-- [core-icons-iife-icon.js](https://static.nrk.no/core-icons/major/16/core-icons-iife-icon.js) Contains all base icons
-- [core-icons-iife-expressive.js](https://static.nrk.no/core-icons/major/16/core-icons-iife-expressive.js) Contains all expressive icon variations
-- [core-icons-iife.js](https://static.nrk.no/core-icons/major/16/core-icons-iife.js) Contains icons and icon variants
-- [core-icons-iife-logo.js](https://static.nrk.no/core-icons/major/16/core-icons-iife-logo.js) Contains all NRK brand logos
-- [core-icons-iife-preview.js](https://static.nrk.no/core-icons/major/16/core-icons-iife-preview.js) Contains all NRK brand previews
+- [core-icons-iife-icon.js](https://static.nrk.no/core-icons/major/18/core-icons-iife-icon.js) Contains all base icons
+- [core-icons-iife-expressive.js](https://static.nrk.no/core-icons/major/18/core-icons-iife-expressive.js) Contains all expressive icon variations
+- [core-icons-iife.js](https://static.nrk.no/core-icons/major/18/core-icons-iife.js) Contains icons and icon variants
+- [core-icons-iife-logo.js](https://static.nrk.no/core-icons/major/18/core-icons-iife-logo.js) Contains all NRK brand logos
+- [core-icons-iife-preview.js](https://static.nrk.no/core-icons/major/18/core-icons-iife-preview.js) Contains all NRK brand previews
 
 For stability, please link to the appropriate major version
 
 ```html
-<script async src="https://static.nrk.no/core-icons/major/16/core-icons-iife.js"></script>
+<script async src="https://static.nrk.no/core-icons/major/18/core-icons-iife.js"></script>
 ```
 
 Linking to `/latest/` is recommended only for prototyping.


### PR DESCRIPTION
Fixes #400

Side note: nrk-rectangle-portrait-to-landscape.svg had fill="black", which broke fill="currentColor" convention. I changed it to match the others. It seems fine.