### PR TITLE
feat: support .astro files in core-icons-codemod

### DIFF
--- a/.changeset/tame-fans-yawn.md
+++ b/.changeset/tame-fans-yawn.md
@@ -1,0 +1,9 @@
+---
+"@nrk/core-icons": patch
+---
+
+core-icons-codemod now rewrites `.astro` files
+
+Astro component frontmatter is plain ESM, so the existing regex-based transform already handles it —
+the files were just excluded by the extension filter in the directory walk. Icon usages in the
+template body are renamed by the same body-rename pass that covers `.vue` and `.svelte` files.

--- a/bin/codemod.js
+++ b/bin/codemod.js
@@ -19,6 +19,7 @@ const EXTENSIONS = new Set([
   '.cts',
   '.vue',
   '.svelte',
+  '.astro',
 ])
 const SKIP_DIRS = new Set([
   'node_modules',

--- a/test/codemod.test.ts
+++ b/test/codemod.test.ts
@@ -140,6 +140,28 @@ describe('codemod', () => {
     expect(result.warnings).toEqual([])
   })
 
+  it('rewrites astro frontmatter imports and template usages', () => {
+    const result = transform(
+      dedent`
+        ---
+        import { nrkLogoNrk } from '@nrk/core-icons/logo';
+        ---
+
+        <Fragment set:html={nrkLogoNrk} />
+      `,
+      map,
+    )
+    expect(result.changed).toBe(true)
+    expect(result.warnings).toEqual([])
+    expect(result.code).toBe(dedent`
+      ---
+      import { nrkLogo } from '@nrk/core-icons/logo';
+      ---
+
+      <Fragment set:html={nrkLogo} />
+    `)
+  })
+
   it('leaves already-migrated code alone', () => {
     const code = "import { magnifyingGlassIcon } from '@nrk/core-icons'"
     const result = transform(code, map)


### PR DESCRIPTION
## What

Adds `.astro` to the codemod's extension filter so Astro components are rewritten like `.vue` and `.svelte` files.

## Why

Astro component frontmatter is plain ESM, so the existing regex-based transform already handles it — the files were just skipped by the directory walk. Found while migrating an Astro-based docs site: the codemod reported `0 file(s) would be rewritten` even when pointed directly at a `.astro` file importing `nrkLogoNrk`.

Icon usages in the template body (e.g. `<Fragment set:html={nrkLogoNrk} />`) are covered by the same body-rename pass as script usages.

## Test

Added a transform test with astro frontmatter + template usage. Verified end-to-end against a real Astro docs site (nrkno/pin-delta-auth docs).